### PR TITLE
Update Agate-sql to version 0.5.8

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
   {{ hash_type }}: {{ hash }}
 
 build:
-  skip: true  # [s390x]
+  skip: true  # [py<36]
   noarch: python
   number: 0
   script: python setup.py install --single-version-externally-managed --record=record.txt

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,6 +35,9 @@ test:
   requires:
     - pip
     - python <3.10
+    # - pyicu
+    - future
+    - parsedatetime
   commands:
     - pip check
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,8 @@ source:
   {{ hash_type }}: {{ hash }}
 
 build:
-  skip: true  # [py<36]
+  # skip s390x due to  missing parsedatatime and agate version >=1.5.0
+  skip: true  # [py<36 or s390x]
   noarch: python
   number: 0
   script: python setup.py install --single-version-externally-managed --record=record.txt

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ build:
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - setuptools
 
   run:
@@ -30,6 +30,11 @@ requirements:
     - sqlalchemy >=1.0.8
 
 test:
+  requires:
+    - pip
+    - python <3.10
+  commands:
+    - pip check
   imports:
     - agatesql
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
   {{ hash_type }}: {{ hash }}
 
 build:
-  # skip s390x due to  missing parsedatatime and agate version >=1.5.0
+  # skip s390x due to  missing parsedatetime and agate version >=1.5.0
   skip: true  # [py<36 or s390x]
   noarch: python
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,7 @@ source:
   {{ hash_type }}: {{ hash }}
 
 build:
+  skip: true  # [s390x]
   noarch: python
   number: 0
   script: python setup.py install --single-version-externally-managed --record=record.txt

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,8 @@ requirements:
   host:
     - python
     - setuptools
+    - pip
+    - wheel
 
   run:
     - python >=3.6
@@ -31,10 +33,10 @@ requirements:
 
 test:
   requires:
-    # - pip
+    - pip
     - python <3.10
   commands:
-    # - pip check
+    - pip check
   imports:
     - agatesql
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,8 @@
 {% set name = "agate-sql" %}
-{% set version = "0.5.6" %}
+{% set version = "0.5.8" %}
 {% set compress_type = "tar.gz" %}
 {% set hash_type = "sha256" %}
-{% set hash = "056dc9e587fbdfdf3f1c9950f4793a5ee87622c19deba31aa0a6d6681816dcde" %}
+{% set hash = "581e062ae878cc087d3d0948670d46b16589df0790bf814524b0587a359f2ada" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,10 +31,10 @@ requirements:
 
 test:
   requires:
-    - pip
+    # - pip
     - python <3.10
   commands:
-    - pip check
+    # - pip check
   imports:
     - agatesql
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,7 @@ test:
   requires:
     - pip
     - python <3.10
-    # - pyicu
+    - pyicu
     - future
     - parsedatetime
   commands:


### PR DESCRIPTION
1. check the upstream
https://github.com/wireservice/agate-sql/tree/0.5.8

2. check the pinnings
https://github.com/wireservice/agate-sql/blob/0.5.8/setup.py
https://github.com/wireservice/agate-sql/blob/0.5.8/setup.cfg
https://github.com/wireservice/agate-sql/blob/0.5.8/example.py

corrected the python pinings

3. check changelogs
https://github.com/wireservice/agate-sql/blob/0.5.8/CHANGELOG.rst

There were only bug fixes mentioned in the change log, for example:
- Fix tests for Linux packages.

4. additional research
https://github.com/conda-forge/agate-sql-feedstock/issues

There are currently no open issues in conda-forge

5. verify dev_url
6. verify doc_url
7. added pip to the test section
8. verify the test section
9. additional tests

In order to test the `agate-sql` package version `0.5.8` the following test was conducted
`conda build agate-sql-feedstock --test`
The test result was the following:
`All tests passed`

In additioon to test the `scvkit` package was used to test `agate` 
`conda build csvkit-feedstock --test`
the test result was the following:
`All tests passed`

Based on the research finding and on the test results we can conclude that it is safe to update `agate-sql` to version `0.5.8`